### PR TITLE
Fix for bulk email merge fields

### DIFF
--- a/src/classes/Smtpapi.cls
+++ b/src/classes/Smtpapi.cls
@@ -57,10 +57,7 @@ global class Smtpapi {
     }
 
     public Header addSubstitution(String key, List<String> val) {
-      for (Integer i = 0; i < val.size(); i++) {
-        List<String> val_in_array = new List<String> { val[i] };
-        this.sub.put(key, val_in_array);
-      }
+      this.sub.put(key, val);
       return this;
     }
 


### PR DESCRIPTION
Before change all emails would send with last merge field value.  Now each email gets the merge field value from the the corresponding index in the list from the second parameter in addSubstitution function of Sendgrid.Email.
